### PR TITLE
ci: add gh actions for issue management

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -1,0 +1,28 @@
+# This workflow posts an automated comment on every new issue
+# https://github.com/marketplace/actions/create-or-update-comment (https://github.com/peter-evans/create-or-update-comment)
+
+name: Automatic Comment
+on:
+  issues:
+    types: [opened]
+permissions:
+  contents: read
+
+jobs:
+  comment:
+    permissions:
+      issues: write # create or update comment
+      pull-requests: write # create or update comment
+    name: Comment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Automatic Comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Thanks for the issue, our team will look into it as soon as possible! If you would like to work on this issue, please wait for a maintainer to decide if it is ready to be worked on.
+
+            To claim an issue, please leave a comment that says ".take". If you have any questions, feel free to ping a maintainer.
+
+          # For full info on how to contribute, please check out our [contributors guide]().

--- a/.github/workflows/take.yml
+++ b/.github/workflows/take.yml
@@ -17,4 +17,4 @@ jobs:
           blockingLabels: needs triage,blocked,core team work,needs design,duplicate
           blockingLabelsMessage: The issue you are trying to assign yourself is blocked until it can be triaged by a maintainer.
           trigger: .take
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/take.yml
+++ b/.github/workflows/take.yml
@@ -1,0 +1,20 @@
+# .github/workflows/take.yml
+name: Assign issue to contributor
+on:
+  issue_comment:
+
+jobs:
+  assign:
+    name: Take an issue
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: take the issue
+        uses: bdougie/take-action@v1.6.1
+        with:
+          issueCurrentlyAssignedMessage: Thanks for being interested in this issue. It looks like this ticket is already assigned to a contributor.
+          blockingLabels: needs triage,blocked,core team work,needs design,duplicate
+          blockingLabelsMessage: The issue you are trying to assign yourself is blocked until it can be triaged by a maintainer.
+          trigger: .take
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This pr adds two workflow files:
- `issue.yml` for welcoming whoever opens an issue
- `take.yml` for assigning issues if a comment contains `.take`.

The trigger(.take) can be changed based on preferences. Please let me know what you think about that. Also, open to feedback regarding the copy used.

## Related Tickets
Fixes #84